### PR TITLE
housekeeping: Enable dependabot for C# projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/src/Jenner.Agendamento.API"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/src/Jenner.Aplicacao.API"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/src/Jenner.Carteira.API"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/src/Jenner.Comum"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nuget"
+    directory: "/src/Jenner.Carteira.Agendador.Worker"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This commit enables automatic PRs for bumping NuGet dependencies.